### PR TITLE
improved rvm_path and rvm_ruby_version usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,25 @@ And then execute:
 
 ## Usage
 
+Include the rvm plugin in your Capfile:
+
     # Capfile
 
     require 'capistrano/rvm'
 
+Set these in every stage file dependant on your server configuration:
+
+    # stage file (production.rb or else)
+
     set :rvm_type, :user # or :system, depends on your rvm setup
     set :rvm_ruby_version, '2.0.0-p247'
 
-Use `:rvm_type` to indicate whether to use a single user installation or rvm
-or a multi-user (or system) installation of rvm. If you specify `:user`,
-capistrano expects to find your rvm installation in `~/.rvm`. If you specify
-`:system`, capistrano expects to find your rvm installation in
-`/usr/local/rvm`. If you have rvm installed elsewhere, use `rvm_custom_path`
-to tell capistrano where it is:
+Use `:rvm_type` to indicate whether to use a single user installation a multi-
+user (or system) installation of rvm. If you specify `:user`, capistrano
+expects to find your rvm installation in `~/.rvm`. If you specify `:system`,
+capistrano expects to find your rvm installation in `/usr/local/rvm`. If you
+have rvm installed elsewhere, use `rvm_custom_path` to tell capistrano where
+it is:
 
     set :rvm_type, :user
     set :rvm_custom_path, '~/.myveryownrvm'

--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -14,31 +14,41 @@ end
 
 namespace :deploy do
   before :starting, :hook_rvm do
+    invoke :'rvm:check_config'
     invoke :'rvm:create_wrappers'
     invoke :'rvm:check'
   end
 end
 
 namespace :rvm do
+  task :check_config do
+    on roles(:all) do
+      rvm_path = fetch(:rvm_custom_path)
+      rvm_path ||= if fetch(:rvm_type) == :system
+        "/usr/local/rvm"
+      else
+        "~/.rvm"
+      end
+      set :rvm_path, rvm_path
+
+      rvm_ruby_version = fetch(:rvm_ruby_version)
+      if rvm_ruby_version.nil?
+        error "rvm: :rvm_ruby_version is not set"
+        exit 1
+      end
+    end
+  end
+
   task :check do
     on roles(:all) do
+      execute :rvm, "version"
       execute :ruby, "--version"
-      # if test "[ ! -d #{rvm_ruby_dir} ]"
-        # error "rvm: #{fetch(:rvm_ruby)} is not installed or not found in #{rvm_ruby_dir}"
-        # exit 1
-      # end
     end
   end
 
   task :create_wrappers do
     on roles(:all) do
-      rvm_ruby = fetch(:rvm_ruby)
-      if rvm_ruby.nil?
-        error "rvm: rvm_ruby is not set"
-        exit 1
-      end
-
-      execute :rvm, "wrapper #{rvm_ruby} #{fetch(:application)} #{fetch(:rvm_map_bins).join(" ")}"
+      execute :rvm, "wrapper #{fetch(:rvm_ruby_version)} #{fetch(:application)} #{fetch(:rvm_map_bins).join(" ")}"
     end
   end
 end
@@ -47,14 +57,5 @@ namespace :load do
   task :defaults do
     set :rvm_map_bins, bundler_loaded? ? %w{rake gem bundle ruby} : %w{rake gem ruby}
     set :rvm_type, :user
-
-    rvm_path = fetch(:rvm_custom_path)
-    rvm_path ||= if fetch(:rvm_type) == :system
-      "/usr/local/rvm"
-    else
-      "~/.rvm"
-    end
-
-    set :rvm_path, rvm_path
   end
 end


### PR DESCRIPTION
Documentation and code were not using the same symbol names.
Changed `Usage` section to indicate different parts for Capfile and stage-files.
