### PR TITLE
user rvm is prefered over system

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Set those in the stage file dependant on your server configuration:
 
 Valid options are:
   * `:auto` (default): just tries to find the correct path.
-                       `/usr/local/rvm` wins over `~/.rvm`
+                       `~/.rvm` wins over `/usr/local/rvm`
   * `:system`: defines the RVM path to `/usr/local/rvm`
   * `:user`: defines the RVM path to `~/.rvm`
 

--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -44,7 +44,9 @@ namespace :rvm do
       rvm_path = fetch(:rvm_custom_path)
       rvm_path ||= case fetch(:rvm_type)
       when :auto
-        if test("[ -d #{RVM_SYSTEM_PATH} ]")
+        if test("[ -d #{RVM_USER_PATH} ]")
+          RVM_USER_PATH
+        elsif test("[ -d #{RVM_SYSTEM_PATH} ]")
           RVM_SYSTEM_PATH
         else
           RVM_USER_PATH


### PR DESCRIPTION
In rvm when used manually the user installation should win over system one, this should be persistent for all tools wrapping rvm.
