### PR TITLE
Add support for mixed mode installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Valid options are:
                        `/usr/local/rvm` wins over `~/.rvm`
   * `:system`: defines the RVM path to `/usr/local/rvm`
   * `:user`: defines the RVM path to `~/.rvm`
+  * `:mixed`: defines the RVM path to `/usr/local/rvm` for rvm and `~/.rvm` for wrapped commands
 
 ### Ruby and gemset selection: `:rvm_ruby_version`
 

--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -7,7 +7,7 @@ end
 
 SSHKit.config.command_map = Hash.new do |hash, key|
   if fetch(:rvm_map_bins).include?(key.to_s)
-    hash[key] = "#{fetch(:rvm_path)}/bin/#{fetch(:application)}_#{key}"
+    hash[key] = "#{fetch(:rvm_bins_path)}/bin/#{fetch(:application)}_#{key}"
   elsif key.to_s == "rvm"
     hash[key] = "#{fetch(:rvm_path)}/bin/rvm"
   else
@@ -49,12 +49,13 @@ namespace :rvm do
         else
           RVM_USER_PATH
         end
-      when :system
+      when :system, :mixed
         RVM_SYSTEM_PATH
       else # :user
         RVM_USER_PATH
       end
       set :rvm_path, rvm_path
+      set :rvm_bins_path, fetch(:rvm_type) == :mixed ? RVM_USER_PATH : rvm_path
 
       rvm_ruby_version = fetch(:rvm_ruby_version)
       rvm_ruby_version ||= capture(:rvm, "current")


### PR DESCRIPTION
Mixed mode installations need to use the system locations for the rvm command and the user location for wrapped commands. What do you think about this for adding support for mixed mode installs?
