### PR TITLE
remove using wrappers, fix #13, fix #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Valid options are:
                        `/usr/local/rvm` wins over `~/.rvm`
   * `:system`: defines the RVM path to `/usr/local/rvm`
   * `:user`: defines the RVM path to `~/.rvm`
-  * `:mixed`: defines the RVM path to `/usr/local/rvm` for rvm and `~/.rvm` for wrapped commands
 
 ### Ruby and gemset selection: `:rvm_ruby_version`
 
@@ -76,10 +75,9 @@ proper ruby and create the gemset.
 
 ## How it works
 
-This gem adds a new task `rvm:hook` before `deploy:starting`. It uses the `rvm
-wrapper` command to create wrapper scripts for this application that use the
-desired ruby and gemset. These wrapper scripts are then used by capistrano
-when it wants to run `rake`, `gem`, `bundle`, or `ruby`.
+This gem adds a new task `rvm:hook` before `deploy:starting`.
+It sets the `rvm ... do ...` for capistrano when it wants to run
+`rake`, `gem`, `bundle`, or `ruby`.
 
 
 ## Check your configuration
@@ -94,14 +92,11 @@ deployment.
 ## Custom tasks which rely on RVM/Ruby
 
 When building custom tasks which need a the corrent ruby and gemset, all you
-have to do is run the `rvm:hook` task before your own task. This will create
-the necessary wrappers and handles the execution of the ruby-related commands.
+have to do is run the `rvm:hook` task before your own task. This will handle
+the execution of the ruby-related commands.
 This is only necessary if your task is *not* *after* the `deploy:starting` task.
 
     before :my_custom_task, 'rvm:hook'
-
-The hook can be called multiple times per `cap` run - it only creates the
-wrappers once.
 
 ## Contributing
 

--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -7,7 +7,7 @@ end
 
 SSHKit.config.command_map = Hash.new do |hash, key|
   if fetch(:rvm_map_bins).include?(key.to_s)
-    hash[key] = "#{fetch(:rvm_bins_path)}/bin/#{fetch(:application)}_#{key}"
+    hash[key] = "#{fetch(:rvm_path)}/bin/rvm #{fetch(:rvm_ruby_version)} do #{key}"
   elsif key.to_s == "rvm"
     hash[key] = "#{fetch(:rvm_path)}/bin/rvm"
   else
@@ -24,7 +24,6 @@ namespace :rvm do
   task :hook do
     unless fetch(:rvm_hooked)
       invoke :'rvm:init'
-      invoke :'rvm:create_wrappers'
       set :rvm_hooked, true
     end
   end
@@ -55,7 +54,6 @@ namespace :rvm do
         RVM_USER_PATH
       end
       set :rvm_path, rvm_path
-      set :rvm_bins_path, fetch(:rvm_type) == :mixed ? RVM_USER_PATH : rvm_path
 
       rvm_ruby_version = fetch(:rvm_ruby_version)
       rvm_ruby_version ||= capture(:rvm, "current")
@@ -63,11 +61,6 @@ namespace :rvm do
     end
   end
 
-  task :create_wrappers do
-    on roles(:all) do
-      execute :rvm, "wrapper #{fetch(:rvm_ruby_version)} #{fetch(:application)} #{fetch(:rvm_map_bins).join(" ")}"
-    end
-  end
 end
 
 namespace :load do


### PR DESCRIPTION
switch to detect the binaries at runtime using `rvm ruby do binary` - this eliminates the need to create wrappers which solves:
- #13 - no need to write anything
- #14 - no need to check application for creating wrappers
