### PR TITLE
remove binstubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Add this line to your application's Gemfile:
 
 And then execute:
 
-    $ bundle --binstubs
-    $ cap install
+    $ bundle install
+    $ bundle exec cap install
 
 ## Usage
 


### PR DESCRIPTION
Using `--binstubs` with `$PATH` is not secure - more details here => http://niczsoft.com/2013/10/please-hack-my-rails/

I have changed the commands for something that will work for everybody and those who use shortcuts will know how to use them.

I also have seen `--binstubs` in other projects, like https://github.com/capistrano/rails  https://github.com/capistrano/capistrano ... and few more, should I open PR for each of them or can someone with commit rights to every of them do the fix?
