### PR TITLE
fix: Don't know how to build task 'rvm:hook'

### DIFF
--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -15,10 +15,6 @@ SSHKit.config.command_map = Hash.new do |hash, key|
   end
 end
 
-namespace :deploy do
-  after :starting, 'rvm:hook'
-end
-
 namespace :rvm do
   desc "Runs the RVM hook - use it before any custom tasks if necessary"
   task :hook do
@@ -70,4 +66,8 @@ namespace :load do
     set :rvm_map_bins, bundler_loaded? ? %w{bundle gem rake ruby} : %w{gem rake ruby}
     set :rvm_type, :auto
   end
+end
+
+namespace :deploy do
+  after :starting, 'rvm:hook'
 end


### PR DESCRIPTION
Moved the deploy => after :starting at the end of file otherwhise, it triggers the task 'rvm:hook' before it's been declared
