### PR TITLE
Update capistrano-rvm.gemspec

### DIFF
--- a/capistrano-rvm.gemspec
+++ b/capistrano-rvm.gemspec
@@ -16,6 +16,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'capistrano', '~> 3.0'
-  gem.add_dependency 'sshkit', '~> 1.2'
 
 end


### PR DESCRIPTION
No need to add sshkit dependency as it is already included in capistrano
