### PR TITLE
update capistrano, sshkit dependencies

### DIFF
--- a/capistrano-rvm.gemspec
+++ b/capistrano-rvm.gemspec
@@ -15,7 +15,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'capistrano', '~> 3.0'
-  gem.add_dependency 'sshkit', '~> 1.2'
-
+  gem.add_dependency 'capistrano', '~> 3.1'
 end


### PR DESCRIPTION
Updated capistrano dependency to latest version 3.1 and removed sshkit dependency as this is included in the capistrano dependencies (~> 1.3)

At the moment it is not possible to use it with capistrano 3.1.
It is also creating a gem conflict when the latest capistrano-rails (1.1) is used as this depends on capistrano 3.1
