### PR TITLE
Allow for overriding of RVM roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,16 @@ or
 
     set :rvm_ruby_version, '2.0.0@mygemset'
 
-
 ### Custom RVM path: `:rvm_custom_path`
 
 If you have a custom RVM setup with a different path then expected, you have
 to define a custom RVM path to tell capistrano where it is.
 
+### Custom Roles: `:rvm_roles`
+
+If you want to restrict RVM usage to a subset of roles, you may set `:rvm_roles`:
+
+    set :rvm_roles, [:app, :web]
 
 ## Restrictions
 

--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -4,7 +4,7 @@ RVM_USER_PATH = "~/.rvm"
 namespace :rvm do
   desc "Prints the RVM and Ruby version on the target host"
   task :check do
-    on roles(:all) do
+    on roles(fetch(:rvm_roles, :all)) do
       puts capture(:rvm, "version")
       puts capture(:rvm, "current")
       puts capture(:ruby, "--version")
@@ -12,7 +12,7 @@ namespace :rvm do
   end
 
   task :hook do
-    on roles(:all) do
+    on roles(fetch(:rvm_roles, :all)) do
       rvm_path = fetch(:rvm_custom_path)
       rvm_path ||= case fetch(:rvm_type)
       when :auto


### PR DESCRIPTION
It is sometimes useful to limit RVM checks and usage to certain roles. This change simply allows for an `:rvm_roles` variable which may be set to specify the roles that RVM operates on. It defaults to `:all`.
