### PR TITLE
suppress this constant RVM checks if QUIET environment variables is set.

### DIFF
--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -5,9 +5,11 @@ namespace :rvm do
   desc "Prints the RVM and Ruby version on the target host"
   task :check do
     on roles(fetch(:rvm_roles, :all)) do
-      puts capture(:rvm, "version")
-      puts capture(:rvm, "current")
-      puts capture(:ruby, "--version")
+      unless ENV['QUIET']
+        puts capture(:rvm, "version")
+        puts capture(:rvm, "current")
+        puts capture(:ruby, "--version")
+      end
     end
   end
 

--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -5,7 +5,7 @@ namespace :rvm do
   desc "Prints the RVM and Ruby version on the target host"
   task :check do
     on roles(fetch(:rvm_roles, :all)) do
-      unless ENV['QUIET']
+      if fetch(:log_level) == :debug
         puts capture(:rvm, "version")
         puts capture(:rvm, "current")
         puts capture(:ruby, "--version")


### PR DESCRIPTION
latest versions of capistrano are so slow that these redundant checks add lots of time to deploys and are only necessary for debugging.

maybe there's a more cap-fu way to suppress them; but for me they run for every deploy and invoke target.

it doesn't help that EACH  cap execute command run in its own sshkit session .... grind, wait, yawn.
