### PR TITLE
Only apply rvm tasks to release_roles

### DIFF
--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -4,7 +4,7 @@ RVM_USER_PATH = "~/.rvm"
 namespace :rvm do
   desc "Prints the RVM and Ruby version on the target host"
   task :check do
-    on roles(fetch(:rvm_roles, :all)) do
+    on release_roles( fetch(:rvm_roles) ) do
       puts capture(:rvm, "version")
       puts capture(:rvm, "current")
       puts capture(:ruby, "--version")
@@ -12,7 +12,7 @@ namespace :rvm do
   end
 
   task :hook do
-    on roles(fetch(:rvm_roles, :all)) do
+    on release_roles( fetch(:rvm_roles) ) do
       rvm_path = fetch(:rvm_custom_path)
       rvm_path ||= case fetch(:rvm_type)
       when :auto
@@ -51,5 +51,6 @@ namespace :load do
     set :rvm_map_bins, %w{gem rake ruby bundle}
     set :rvm_type, :auto
     set :rvm_ruby_version, "default"
+    set :rvm_roles, :all
   end
 end


### PR DESCRIPTION
This will honor the :no_release option set on a server, e.g.,

``` ruby
server 'monsoon.example.com',
  user:         'vagrant',
  roles:        'support',
  no_release:   true
```
