### PR TITLE
rvm_map_bins should contain rails

### DIFF
--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -48,7 +48,7 @@ end
 
 namespace :load do
   task :defaults do
-    set :rvm_map_bins, %w{gem rake ruby bundle}
+    set :rvm_map_bins, %w{gem rake ruby bundle rails}
     set :rvm_type, :auto
     set :rvm_ruby_version, "default"
   end


### PR DESCRIPTION
The rails command should be included in the `rvm_map_bins` as it is in the capistrano-rbenv gem
