### PR TITLE
Feature/respect ruby version file

### DIFF
--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -52,7 +52,7 @@ end
 
 namespace :load do
   task :defaults do
-    Rake::Task["load:set_rvm_defaults"].execute("default")
+    Rake::Task["load:set_rvm_defaults"].execute("current")
   end
 
   task :set_rvm_defaults do |task, ruby_version|

--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -5,11 +5,9 @@ namespace :rvm do
   desc "Prints the RVM and Ruby version on the target host"
   task :check do
     on roles(fetch(:rvm_roles, :all)) do
-      if fetch(:log_level) == :debug
-        puts capture(:rvm, "version")
-        puts capture(:rvm, "current")
-        puts capture(:ruby, "--version")
-      end
+      puts capture(:rvm, "version")
+      puts capture(:rvm, "current")
+      puts capture(:ruby, "--version")
     end
   end
 
@@ -45,7 +43,9 @@ end
 
 Capistrano::DSL.stages.each do |stage|
   after stage, 'rvm:hook'
-  after stage, 'rvm:check'
+  if fetch(:log_level) == :debug
+    after stage, 'rvm:check'
+  end
 end
 
 namespace :load do

--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -36,11 +36,8 @@ namespace :rvm do
 
     SSHKit.config.command_map[:rvm] = "#{fetch(:rvm_path)}/bin/rvm"
 
-    # Use proc for rvm_prefix once capistrano supports it
-    rvm_prefix = "#{fetch(:rvm_path)}/bin/rvm #{fetch(:rvm_ruby_version)} do"
+    rvm_prefix = proc{ "#{fetch(:rvm_path)}/bin/rvm #{fetch(:rvm_ruby_version)} do" }
     fetch(:rvm_map_bins).each do |command|
-      # We could remove that hack once capistrano supports procs for SSHKit.config.command_map.prefix
-      SSHKit.config.command_map.prefix[command.to_sym].reject!{ |cmd| cmd =~ /bin\/rvm / }
       SSHKit.config.command_map.prefix[command.to_sym].unshift(rvm_prefix)
     end
   end
@@ -62,9 +59,6 @@ namespace :load do
     set :rvm_map_bins, %w{gem rake ruby bundle}
     set :rvm_type, :auto
     set :rvm_ruby_version, ruby_version
-
-    # We could remove that hack once capistrano supports procs for SSHKit.config.command_map.prefix
-    Rake::Task["rvm:hook"].execute
   end
 end
 

--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -55,8 +55,12 @@ namespace :load do
     set :rvm_map_bins, %w{gem rake ruby bundle}
     set :rvm_type, :auto
     set :rvm_ruby_version, proc{
-      within release_path do
-        capture(:rvm, "current")
+      "".tap do |ruby_version|
+        on primary(:app) do
+          within release_path do
+            ruby_version << capture(:rvm, "current")
+          end
+        end
       end
     }
   end

--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -54,6 +54,10 @@ namespace :load do
   task :defaults do
     set :rvm_map_bins, %w{gem rake ruby bundle}
     set :rvm_type, :auto
-    set :rvm_ruby_version, "default"
+    set :rvm_ruby_version, proc{
+      within release_path do
+        capture(:rvm, "current")
+      end
+    }
   end
 end

--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -5,9 +5,11 @@ namespace :rvm do
   desc "Prints the RVM and Ruby version on the target host"
   task :check do
     on roles(fetch(:rvm_roles, :all)) do
-      puts capture(:rvm, "version")
-      puts capture(:rvm, "current")
-      puts capture(:ruby, "--version")
+      within release_path do
+        puts capture(:rvm, "version")
+        puts capture(:rvm, "current")
+        puts capture(:ruby, "--version")
+      end
     end
   end
 


### PR DESCRIPTION
1. Running `cap staging rvm:check` now always outputs something, not only when `log_level` is set to `debug`. It's now only automatically invoked on normal deploying if the `log_level` is `debug`, so no change in behavior here.
2. `cap staging rvm:check` is now executed in the current release path, so RVM will pickup any `.ruby-version` file and only fall back to the system defaults.
3. `rvm_ruby_version` is no longer set to `default`. Instead the ruby version reported by `cap staging rvm:check` is used by default now.
