### PR TITLE
Support specifying different ruby versions for binaries

### DIFF
--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -36,8 +36,10 @@ namespace :rvm do
 
     SSHKit.config.command_map[:rvm] = "#{fetch(:rvm_path)}/bin/rvm"
 
-    rvm_prefix = "#{fetch(:rvm_path)}/bin/rvm #{fetch(:rvm_ruby_version)} do"
-    fetch(:rvm_map_bins).each do |command|
+    fetch(:rvm_map_bins).each do |(command, rvm_ruby_version)|
+      rvm_ruby_version ||= fetch(:rvm_ruby_version)
+
+      rvm_prefix = "#{fetch(:rvm_path)}/bin/rvm #{rvm_ruby_version} do"
       SSHKit.config.command_map.prefix[command.to_sym].unshift(rvm_prefix)
     end
   end


### PR DESCRIPTION
Support prefixing different binaries with different ruby versions

For example

``` ruby
set :rvm_ruby_version, 'ruby-2.0.0-p481'
# eye, a process manager, runs with ruby-2.2.0
# clockwork can run with the configured ruby version ruby-2.0.0-p481
set :rvm_map_bins, fetch(:rvm_map_bins, []).push(['eye', 'ruby-2.2.0'], 'clockwork')
```
