### PR TITLE
Only run hook before deploy, not when stage is set

### DIFF
--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -13,6 +13,8 @@ namespace :rvm do
     end
   end
 
+  before :check, :hook
+
   task :hook do
     on roles(fetch(:rvm_roles, :all)) do
       rvm_path = fetch(:rvm_custom_path)
@@ -43,10 +45,7 @@ namespace :rvm do
   end
 end
 
-Capistrano::DSL.stages.each do |stage|
-  after stage, 'rvm:hook'
-  after stage, 'rvm:check'
-end
+before :deploy, 'rvm:hook'
 
 namespace :load do
   task :defaults do


### PR DESCRIPTION
The README states that it would work this way, but it doesn't.
Running the hook, when stage is set breaks a lot of stuff (e.g. when rvm isn't even installed and you want to write a task that installs it). 
