### PR TITLE
Enable skipping of rvm tasks

### DIFF
--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -48,7 +48,13 @@ end
 def should_skip
   skip_rvm_for_tasks = fetch(:skip_rvm_for_tasks, [])
   invoked_with_task = Rake.application.top_level_tasks.last
-  skip_rvm_for_tasks.any? { |t| Regexp.new(t).match(invoked_with_task) }
+  skip_rvm_for_tasks.any? do |t|
+    if t.is_a?(Regexp)
+      t.match(invoked_with_task)
+    else
+      t == invoked_with_task
+    end
+  end
 end
 
 Capistrano::DSL.stages.each do |stage|

--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -4,6 +4,7 @@ RVM_USER_PATH = "~/.rvm"
 namespace :rvm do
   desc "Prints the RVM and Ruby version on the target host"
   task :check do
+    next if should_skip
     on roles(fetch(:rvm_roles, :all)) do
       if fetch(:log_level) == :debug
         puts capture(:rvm, "version")
@@ -14,6 +15,7 @@ namespace :rvm do
   end
 
   task :hook do
+    next if should_skip
     on roles(fetch(:rvm_roles, :all)) do
       rvm_path = fetch(:rvm_custom_path)
       rvm_path ||= case fetch(:rvm_type)
@@ -41,6 +43,12 @@ namespace :rvm do
       SSHKit.config.command_map.prefix[command.to_sym].unshift(rvm_prefix)
     end
   end
+end
+
+def should_skip
+  skip_rvm_for_tasks = fetch(:skip_rvm_for_tasks, [])
+  invoked_with_task = Rake.application.top_level_tasks.last
+  skip_rvm_for_tasks.any? { |t| Regexp.new(t).match(invoked_with_task) }
 end
 
 Capistrano::DSL.stages.each do |stage|


### PR DESCRIPTION
When executing capistrano task which does not execute any ruby code at target host, checking of rvm and ruby versions is unnecessary. This commit enables skipping of rvm hooks by specifying `:skip_rvm_for_tasks` variable, containing an array of strings/regexes against which currently executing top-level capistrano task is matched.

Related to #45 
