### PR TITLE
Avoid using puts for debug-messages

### DIFF
--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -6,9 +6,9 @@ namespace :rvm do
   task :check do
     on roles(fetch(:rvm_roles, :all)) do
       if fetch(:log_level) == :debug
-        puts capture(:rvm, "version")
-        puts capture(:rvm, "current")
-        puts capture(:ruby, "--version")
+        debug capture(:rvm, "version")
+        debug capture(:rvm, "current")
+        debug capture(:ruby, "--version")
       end
     end
   end


### PR DESCRIPTION
`puts` does bypass the logger the following that bypass output-formatting of gems like airbrussh. Therefore, I changed it to `debug` which invokes the logger and adds the right level. Now the output can be formatted according to the wishes of the user.

In order to avoid the time-penalty of collecting the data, the wrapping conditional still makes sense. If the user does not want to see debug-messages, they probably should not be collected in the first place. (See #42)
