### PR TITLE
Ability to require without hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ Require in Capfile to use the default task:
 
 And you should be good to go!
 
+### Explicitely require hooks
+
+Alternatively, if you want to have control on the execution of nvm tasks
+
+```ruby
+# Capfile
+require capistrano/rbenv/without_hooks
+```
+
+You can then add the hooks on a per deploy script basis
+
+```ruby
+# config/deploy/my_stage_with_rvm.rb
+Capistrano::DSL.stages.each do |stage|
+  after stage, 'rvm:hook'
+  after stage, 'rvm:check'
+end
+```
+
 ## Configuration
 
 Everything *should work* for a basic RVM setup *out of the box*.

--- a/lib/capistrano/hooks/rvm.rb
+++ b/lib/capistrano/hooks/rvm.rb
@@ -1,0 +1,4 @@
+Capistrano::DSL.stages.each do |stage|
+  after stage, 'rvm:hook'
+  after stage, 'rvm:check'
+end

--- a/lib/capistrano/rvm/without_hooks.rb
+++ b/lib/capistrano/rvm/without_hooks.rb
@@ -1,1 +1,1 @@
-load File.expand_path('../../tasks/rvm.rb', __FILE__)
+load File.expand_path('../../tasks/rvm.rake', __FILE__)

--- a/lib/capistrano/rvm/without_hooks.rb
+++ b/lib/capistrano/rvm/without_hooks.rb
@@ -1,0 +1,1 @@
+load File.expand_path('../../tasks/rvm.rb', __FILE__)

--- a/lib/capistrano/tasks/deploy_rvm.rake
+++ b/lib/capistrano/tasks/deploy_rvm.rake
@@ -1,0 +1,2 @@
+load File.expand_path('../rvm.rake', __FILE__)
+load File.expand_path('../../hooks/rvm.rb', __FILE__)

--- a/lib/capistrano/tasks/rvm.rake
+++ b/lib/capistrano/tasks/rvm.rake
@@ -43,11 +43,6 @@ namespace :rvm do
   end
 end
 
-Capistrano::DSL.stages.each do |stage|
-  after stage, 'rvm:hook'
-  after stage, 'rvm:check'
-end
-
 namespace :load do
   task :defaults do
     set :rvm_map_bins, %w{gem rake ruby bundle}


### PR DESCRIPTION
for https://github.com/capistrano/rvm/issues/49

to test with

```ruby
gem 'capistrano-rvm',
    git: 'https://github.com/Startouf/rvm',
    branch: 'feature/require-without-hooks',
    require: false
```